### PR TITLE
feat: 优化正则匹配规则与数字解析

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -14,7 +14,7 @@ DEFAULT_CONFIG = {
     "chap_suffix": "章",
     "custom_suffixes": ["章", "回", "节", "话", "集"],
     "enable_volume": False,
-    "vol_regex": r"第\s*([0-9]+|[零〇一二三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟萬两]+)\s*[卷部]",
+    "vol_regex": r"第\s*([0-9]+|[零〇一二三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟萬两]+)\s*[卷部辑册幕篇]",
     "chap_reset_mode": "reset_1",
     "auto_detect_reset": False,
 }
@@ -72,22 +72,37 @@ def cn2an_simple(text):
     Examples: 十二->12, 一百二十三->123, 二千零五->2005, 一万二千三百四十五->12345
     """
     cn_nums = {
-        "零": 0, "〇": 0,
-        "一": 1, "壹": 1,
-        "二": 2, "贰": 2, "两": 2,
-        "三": 3, "叁": 3,
-        "四": 4, "肆": 4,
-        "五": 5, "伍": 5,
-        "六": 6, "陆": 6,
-        "七": 7, "柒": 7,
-        "八": 8, "捌": 8,
-        "九": 9, "玖": 9,
+        "零": 0,
+        "〇": 0,
+        "一": 1,
+        "壹": 1,
+        "二": 2,
+        "贰": 2,
+        "两": 2,
+        "三": 3,
+        "叁": 3,
+        "四": 4,
+        "肆": 4,
+        "五": 5,
+        "伍": 5,
+        "六": 6,
+        "陆": 6,
+        "七": 7,
+        "柒": 7,
+        "八": 8,
+        "捌": 8,
+        "九": 9,
+        "玖": 9,
     }
     cn_units = {
-        "十": 10, "拾": 10,
-        "百": 100, "佰": 100,
-        "千": 1000, "仟": 1000,
-        "万": 10000, "萬": 10000,
+        "十": 10,
+        "拾": 10,
+        "百": 100,
+        "佰": 100,
+        "千": 1000,
+        "仟": 1000,
+        "万": 10000,
+        "萬": 10000,
     }
 
     text = text.strip()
@@ -120,7 +135,12 @@ def cn2an_simple(text):
                 current_section = 0
                 current_num = 0
             else:
-                if current_num == 0 and unit == 10 and current_section == 0 and wan_part == 0:
+                if (
+                    current_num == 0
+                    and unit == 10
+                    and current_section == 0
+                    and wan_part == 0
+                ):
                     current_num = 1
                 current_section += current_num * unit
                 current_num = 0
@@ -198,7 +218,7 @@ def format_missing_chapters(missing, group_size=30):
 
     lines = []
     for i in range(0, total, group_size):
-        group = missing[i:i + group_size]
+        group = missing[i : i + group_size]
         group_start = i + 1
         group_end = min(i + group_size, total)
         group_str = ", ".join(str(x) for x in group)
@@ -207,7 +227,9 @@ def format_missing_chapters(missing, group_size=30):
     return "\n" + "\n".join(lines)
 
 
-def check_sequence_report(numbers, context_name="", mode="reset_1", prev_end=None, original_order=None):
+def check_sequence_report(
+    numbers, context_name="", mode="reset_1", prev_end=None, original_order=None
+):
     """
     检查序列连续性并返回报告。
     Returns: (last_number, report_lines_list, missing_list)
@@ -254,25 +276,26 @@ def check_sequence_report(numbers, context_name="", mode="reset_1", prev_end=Non
     if original_order and len(original_order) > 1:
         order_issues = []
         for i in range(1, len(original_order)):
-            prev_num = original_order[i-1]
+            prev_num = original_order[i - 1]
             curr_num = original_order[i]
             diff = curr_num - prev_num
             # 检测大跳跃（跳过超过1章）或倒退
             if diff > 1:
-                order_issues.append(f"{prev_num}→{curr_num} (跳过{diff-1}章)")
+                order_issues.append(f"{prev_num}→{curr_num} (跳过{diff - 1}章)")
             elif diff < 0:
                 order_issues.append(f"{prev_num}→{curr_num} (倒退)")
-        
+
         if order_issues:
             report.append(f"   ⚠️  顺序异常 ({len(order_issues)} 处):")
             for issue in order_issues[:10]:
                 report.append(f"      • {issue}")
             if len(order_issues) > 10:
                 report.append(f"      ... 等 {len(order_issues)} 处")
-    
+
     # 检测重复章节
     if len(numbers) != len(set(numbers)):
         from collections import Counter
+
         counter = Counter(numbers)
         duplicates = [(num, count) for num, count in counter.items() if count > 1]
         if duplicates:
@@ -306,52 +329,56 @@ def analyze_chapter_format(texts, config):
     suffix = config["chap_suffix"]
     num_type = config.get("chap_num_type", "mixed")
     num_pat = NUM_PATTERNS.get(num_type, NUM_PATTERNS["mixed"])
-    
-    if "|" in suffix and not (suffix.startswith("(") and suffix.endswith(")")):
-        real_suffix = f"(?:{suffix})"
+
+    # 转义前缀和后缀，但保留后缀中的 '|' 逻辑
+    escaped_prefix = re.escape(prefix)
+    if "|" in suffix:
+        # 如果包含 |，按 | 分割，转义每一部分后再合并
+        parts = [re.escape(p.strip()) for p in suffix.split("|") if p.strip()]
+        real_suffix = f"(?:{'|'.join(parts)})"
     else:
-        real_suffix = suffix
-    
-    chap_regex_str = f"{prefix}\\s*({num_pat})\\s*{real_suffix}"
+        real_suffix = re.escape(suffix)
+
+    chap_regex_str = f"{escaped_prefix}\\s*({num_pat})\\s*{real_suffix}"
     vol_regex_str = config.get("vol_regex", "")
-    
+
     try:
         chap_re = re.compile(chap_regex_str)
         vol_re = re.compile(vol_regex_str) if vol_regex_str else None
     except:
         return None
-    
+
     num_types = {"arabic": 0, "cn_lower": 0, "cn_upper": 0, "variant": 0}
     sample_chapters = []
     has_volume = False
-    
+
     cn_lower_chars = set("零〇一二三四五六七八九十百千万两")
     cn_upper_chars = set("壹贰叁肆伍陆柒捌玖拾佰仟萬")
-    
+
     for t in texts:
         if vol_re and vol_re.search(t):
             has_volume = True
             continue
-        
+
         cm = chap_re.search(t)
         if cm:
             num_str = cm.group(1)
-            
+
             if num_str.isdigit():
                 num_types["arabic"] += 1
             elif any(c in cn_upper_chars for c in num_str):
                 num_types["cn_upper"] += 1
             elif any(c in cn_lower_chars for c in num_str):
                 num_types["cn_lower"] += 1
-            
+
             if "〇" in num_str or "两" in num_str:
                 num_types["variant"] += 1
-            
+
             if len(sample_chapters) < 5:
                 sample_chapters.append(t.strip()[:30])
-    
+
     total = sum(num_types.values()) - num_types["variant"]
-    
+
     return {
         "prefix": prefix,
         "suffix": suffix,
@@ -371,25 +398,28 @@ def get_chapter_info_from_nav(bk, config):
         return None, None, {}
 
     content = bk.readfile(file_id)
-    
+
     prefix = config["chap_prefix"]
     num_type = config.get("chap_num_type", "mixed")
     num_pat = NUM_PATTERNS.get(num_type, NUM_PATTERNS["mixed"])
     suffix = config["chap_suffix"]
-    if "|" in suffix and not (suffix.startswith("(") and suffix.endswith(")")):
-        real_suffix = f"(?:{suffix})"
+
+    escaped_prefix = re.escape(prefix)
+    if "|" in suffix:
+        parts = [re.escape(p.strip()) for p in suffix.split("|") if p.strip()]
+        real_suffix = f"(?:{'|'.join(parts)})"
     else:
-        real_suffix = suffix
-    chap_regex_str = f"{prefix}\\s*({num_pat})\\s*{real_suffix}"
-    
+        real_suffix = re.escape(suffix)
+    chap_regex_str = f"{escaped_prefix}\\s*({num_pat})\\s*{real_suffix}"
+
     try:
         chap_re = re.compile(chap_regex_str)
     except:
         return file_id, content, {}
-    
+
     chapter_map = {}
     pattern = re.compile(r'<a[^>]*href="([^"]*)"[^>]*>([^<]*)</a>', re.IGNORECASE)
-    
+
     for match in pattern.finditer(content):
         href = match.group(1)
         text = match.group(2).strip()
@@ -400,7 +430,7 @@ def get_chapter_info_from_nav(bk, config):
                 chapter_map[c_num] = href
             except:
                 pass
-    
+
     return file_id, content, chapter_map
 
 
@@ -409,18 +439,18 @@ def find_nearest_existing_href(missing_num, chapter_map, all_chapters):
     找到缺失章节应该指向的 href（下一个存在的章节，如果没有则往上找）。
     """
     sorted_chapters = sorted(all_chapters)
-    
+
     for c in sorted_chapters:
         if c > missing_num and c in chapter_map:
             return chapter_map[c]
-    
+
     for c in reversed(sorted_chapters):
         if c < missing_num and c in chapter_map:
             return chapter_map[c]
-    
+
     if chapter_map:
         return list(chapter_map.values())[0]
-    
+
     return "#"
 
 
@@ -430,27 +460,27 @@ def insert_missing_chapters_to_nav(bk, config, missing_chapters):
     返回: (成功数, 错误信息)
     """
     file_id, content, chapter_map = get_chapter_info_from_nav(bk, config)
-    
+
     if not file_id:
         return 0, "未找到 nav.xhtml 文件"
-    
+
     if not chapter_map:
         return 0, "无法解析现有章节信息"
-    
+
     prefix = config["chap_prefix"]
     suffix = config["chap_suffix"]
     all_chapters = set(chapter_map.keys())
-    
+
     inserted = 0
     new_content = content
-    
+
     for missing_num in sorted(missing_chapters, reverse=True):
         target_href = find_nearest_existing_href(missing_num, chapter_map, all_chapters)
-        
+
         missing_title = f"{MISSING_MARKER}{prefix}{missing_num}{suffix}"
-        
+
         new_li = f'<li class="{MISSING_CLASS}"><a href="{target_href}">{missing_title}</a></li>'
-        
+
         next_chapters = [c for c in sorted(all_chapters) if c > missing_num]
         if next_chapters:
             next_chap = min(next_chapters)
@@ -458,14 +488,19 @@ def insert_missing_chapters_to_nav(bk, config, missing_chapters):
             if next_href:
                 pattern = re.compile(
                     rf'(<li[^>]*>\s*<a[^>]*href="{re.escape(next_href)}"[^>]*>[^<]*</a>\s*</li>)',
-                    re.IGNORECASE | re.DOTALL
+                    re.IGNORECASE | re.DOTALL,
                 )
                 match = pattern.search(new_content)
                 if match:
-                    new_content = new_content[:match.start()] + new_li + "\n" + new_content[match.start():]
+                    new_content = (
+                        new_content[: match.start()]
+                        + new_li
+                        + "\n"
+                        + new_content[match.start() :]
+                    )
                     inserted += 1
                     continue
-        
+
         prev_chapters = [c for c in sorted(all_chapters) if c < missing_num]
         if prev_chapters:
             prev_chap = max(prev_chapters)
@@ -473,17 +508,22 @@ def insert_missing_chapters_to_nav(bk, config, missing_chapters):
             if prev_href:
                 pattern = re.compile(
                     rf'(<li[^>]*>\s*<a[^>]*href="{re.escape(prev_href)}"[^>]*>[^<]*</a>\s*</li>)',
-                    re.IGNORECASE | re.DOTALL
+                    re.IGNORECASE | re.DOTALL,
                 )
                 match = pattern.search(new_content)
                 if match:
-                    new_content = new_content[:match.end()] + "\n" + new_li + new_content[match.end():]
+                    new_content = (
+                        new_content[: match.end()]
+                        + "\n"
+                        + new_li
+                        + new_content[match.end() :]
+                    )
                     inserted += 1
                     continue
-    
+
     if inserted > 0:
         bk.writefile(file_id, new_content)
-    
+
     return inserted, None
 
 
@@ -493,29 +533,29 @@ def remove_missing_placeholders(bk):
     返回: (删除数, 错误信息)
     """
     file_id, toc_type = get_toc_source(bk)
-    
+
     if not file_id or toc_type != "nav":
         return 0, "未找到 nav.xhtml 文件"
-    
+
     content = bk.readfile(file_id)
-    
+
     pattern = re.compile(
         rf'<li[^>]*class="[^"]*{MISSING_CLASS}[^"]*"[^>]*>.*?</li>\s*',
-        re.IGNORECASE | re.DOTALL
+        re.IGNORECASE | re.DOTALL,
     )
-    
-    new_content, count = pattern.subn('', content)
-    
+
+    new_content, count = pattern.subn("", content)
+
     if count == 0:
         pattern2 = re.compile(
-            rf'<li[^>]*>\s*<a[^>]*>[^<]*{re.escape(MISSING_MARKER)}[^<]*</a>\s*</li>\s*',
-            re.IGNORECASE | re.DOTALL
+            rf"<li[^>]*>\s*<a[^>]*>[^<]*{re.escape(MISSING_MARKER)}[^<]*</a>\s*</li>\s*",
+            re.IGNORECASE | re.DOTALL,
         )
-        new_content, count = pattern2.subn('', content)
-    
+        new_content, count = pattern2.subn("", content)
+
     if count > 0:
         bk.writefile(file_id, new_content)
-    
+
     return count, None
 
 
@@ -545,7 +585,7 @@ class MainDialog(QDialog):
         self.inp_prefix.setPlaceholderText("第")
         row1.addWidget(self.inp_prefix)
         row1.addSpacing(20)
-        
+
         row1.addWidget(QLabel("数字类型:"))
         self.combo_num_type = QComboBox()
         self.combo_num_type.addItem("混合模式", "mixed")
@@ -568,7 +608,9 @@ class MainDialog(QDialog):
         self.combo_suffix = QComboBox()
         self.combo_suffix.setEditable(True)
         self.combo_suffix.setMinimumWidth(100)
-        custom_suffixes = self.config.get("custom_suffixes", ["章", "回", "节", "话", "集"])
+        custom_suffixes = self.config.get(
+            "custom_suffixes", ["章", "回", "节", "话", "集"]
+        )
         self.combo_suffix.addItems(custom_suffixes)
         current_suffix = self.config.get("chap_suffix", "章")
         idx = self.combo_suffix.findText(current_suffix)
@@ -602,7 +644,7 @@ class MainDialog(QDialog):
         # 卷/部设置区域
         grp_vol = QGroupBox("卷/部设置（可选）")
         vol_main = QVBoxLayout()
-        
+
         # 第一行：启用卷检测 + 卷正则
         vol_row1 = QHBoxLayout()
         self.chk_enable_vol = QCheckBox("启用卷/部检测")
@@ -610,20 +652,24 @@ class MainDialog(QDialog):
         vol_row1.addWidget(self.chk_enable_vol)
         vol_row1.addWidget(QLabel("卷正则:"))
         self.inp_vol_regex = QLineEdit(self.config.get("vol_regex", ""))
-        self.inp_vol_regex.setPlaceholderText("第\\s*([0-9]+|[零〇一二三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟萬两]+)\\s*[卷部]")
+        self.inp_vol_regex.setPlaceholderText(
+            "第\\s*([0-9]+|[零〇一二三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟萬两]+)\\s*[卷部]"
+        )
         self.inp_vol_regex.setEnabled(self.chk_enable_vol.isChecked())
         self.chk_enable_vol.toggled.connect(self.inp_vol_regex.setEnabled)
         vol_row1.addWidget(self.inp_vol_regex, 1)
         vol_main.addLayout(vol_row1)
-        
+
         # 第二行：自动检测章节重置
         vol_row2 = QHBoxLayout()
-        self.chk_auto_reset = QCheckBox("自动检测章节重置（无卷标题时，章节号从大变小自动分段）")
+        self.chk_auto_reset = QCheckBox(
+            "自动检测章节重置（无卷标题时，章节号从大变小自动分段）"
+        )
         self.chk_auto_reset.setChecked(self.config.get("auto_detect_reset", False))
         vol_row2.addWidget(self.chk_auto_reset)
         vol_row2.addStretch()
         vol_main.addLayout(vol_row2)
-        
+
         grp_vol.setLayout(vol_main)
         layout.addWidget(grp_vol)
 
@@ -636,25 +682,27 @@ class MainDialog(QDialog):
         self.btn_save = QPushButton("保存设置")
         self.btn_save.setMinimumHeight(36)
         self.btn_save.clicked.connect(self.do_save)
-        
+
         btn_layout.addWidget(self.btn_check)
         btn_layout.addWidget(self.btn_save)
         btn_layout.addSpacing(20)
-        
+
         # 缺失章节操作按钮
         self.btn_insert = QPushButton("插入缺失占位")
         self.btn_insert.setMinimumHeight(36)
-        self.btn_insert.setToolTip(f"在 nav 目录中插入缺失章节占位符\n标记: {MISSING_MARKER}")
+        self.btn_insert.setToolTip(
+            f"在 nav 目录中插入缺失章节占位符\n标记: {MISSING_MARKER}"
+        )
         self.btn_insert.clicked.connect(self.do_insert_missing)
         self.btn_remove = QPushButton("删除占位符")
         self.btn_remove.setMinimumHeight(36)
         self.btn_remove.setToolTip(f"删除所有带 {MISSING_MARKER} 标记的占位符")
         self.btn_remove.clicked.connect(self.do_remove_placeholders)
-        
+
         btn_layout.addWidget(self.btn_insert)
         btn_layout.addWidget(self.btn_remove)
         btn_layout.addStretch()
-        
+
         self.btn_close = QPushButton("关闭")
         self.btn_close.setMinimumHeight(36)
         self.btn_close.clicked.connect(self.reject)
@@ -683,7 +731,9 @@ class MainDialog(QDialog):
             self.text_result.setPlainText(f"✅ 已添加后缀「{current}」")
 
     def get_config(self):
-        suffixes = [self.combo_suffix.itemText(i) for i in range(self.combo_suffix.count())]
+        suffixes = [
+            self.combo_suffix.itemText(i) for i in range(self.combo_suffix.count())
+        ]
         return {
             "chap_prefix": self.inp_prefix.text(),
             "chap_num_type": self.combo_num_type.currentData(),
@@ -710,10 +760,10 @@ class MainDialog(QDialog):
         self.text_result.setPlainText(result_text)
 
     def do_insert_missing(self):
-        if not hasattr(self, 'last_missing') or not self.last_missing:
+        if not hasattr(self, "last_missing") or not self.last_missing:
             self.text_result.setPlainText("⚠️ 请先点击「开始检查」获取缺失章节列表")
             return
-        
+
         reply = QMessageBox.question(
             self,
             "确认插入",
@@ -722,12 +772,14 @@ class MainDialog(QDialog):
             f"占位符将指向最近的现有章节。\n\n"
             f"确定继续?",
             QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No
+            QMessageBox.No,
         )
-        
+
         if reply == QMessageBox.Yes:
             config = self.get_config()
-            count, err = insert_missing_chapters_to_nav(self.bk, config, self.last_missing)
+            count, err = insert_missing_chapters_to_nav(
+                self.bk, config, self.last_missing
+            )
             if err:
                 self.text_result.setPlainText(f"❌ 插入失败: {err}")
             else:
@@ -744,9 +796,9 @@ class MainDialog(QDialog):
             "确认删除",
             f"将删除 nav 目录中所有带 {MISSING_MARKER} 标记的占位符。\n\n确定继续?",
             QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No
+            QMessageBox.No,
         )
-        
+
         if reply == QMessageBox.Yes:
             count, err = remove_missing_placeholders(self.bk)
             if err:
@@ -765,35 +817,37 @@ def split_by_reset(chapters):
     """
     if not chapters:
         return []
-    
+
     segments = []
     current_segment = [chapters[0]]
-    
+
     for i in range(1, len(chapters)):
-        if chapters[i] < chapters[i-1]:
+        if chapters[i] < chapters[i - 1]:
             segments.append(current_segment)
             current_segment = [chapters[i]]
         else:
             current_segment.append(chapters[i])
-    
+
     if current_segment:
         segments.append(current_segment)
-    
+
     return segments
 
 
 def perform_check(bk, config):
     prefix = config["chap_prefix"]
+    suffix = config["chap_suffix"]
     num_type = config.get("chap_num_type", "mixed")
     num_pat = NUM_PATTERNS.get(num_type, NUM_PATTERNS["mixed"])
-    suffix = config["chap_suffix"]
 
-    if "|" in suffix and not (suffix.startswith("(") and suffix.endswith(")")):
-        real_suffix = f"(?:{suffix})"
+    escaped_prefix = re.escape(prefix)
+    if "|" in suffix:
+        parts = [re.escape(p.strip()) for p in suffix.split("|") if p.strip()]
+        real_suffix = f"(?:{'|'.join(parts)})"
     else:
-        real_suffix = suffix
+        real_suffix = re.escape(suffix)
 
-    chap_regex_str = f"{prefix}\\s*({num_pat})\\s*{real_suffix}"
+    chap_regex_str = f"{escaped_prefix}\\s*({num_pat})\\s*{real_suffix}"
     enable_vol = config["enable_volume"]
     vol_regex_str = config["vol_regex"]
     mode = config["chap_reset_mode"]
@@ -803,7 +857,7 @@ def perform_check(bk, config):
     toc_info = f"{toc_type.upper()}" if toc_type else "未找到"
 
     report_lines = []
-    
+
     # 输出配置信息
     report_lines.append("=" * 50)
     report_lines.append("📋 检测配置")
@@ -835,28 +889,30 @@ def perform_check(bk, config):
         report_lines.append("📊 目录分析")
         report_lines.append("=" * 50)
         report_lines.append(f"   识别章节数: {analysis['total_chapters']}")
-        
-        nt = analysis['num_types']
+
+        nt = analysis["num_types"]
         type_parts = []
-        if nt['arabic'] > 0:
+        if nt["arabic"] > 0:
             type_parts.append(f"阿拉伯数字 {nt['arabic']}")
-        if nt['cn_lower'] > 0:
+        if nt["cn_lower"] > 0:
             type_parts.append(f"中文小写 {nt['cn_lower']}")
-        if nt['cn_upper'] > 0:
+        if nt["cn_upper"] > 0:
             type_parts.append(f"中文大写 {nt['cn_upper']}")
         if type_parts:
             report_lines.append(f"   数字分布: {', '.join(type_parts)}")
-        
-        if nt['variant'] > 0:
+
+        if nt["variant"] > 0:
             report_lines.append(f"   变体字符: 有 ({nt['variant']} 处，含〇或两)")
         else:
             report_lines.append(f"   变体字符: 无")
-        
-        report_lines.append(f"   检测到分卷: {'是' if analysis['has_volume'] else '否'}")
-        
-        if analysis['sample_chapters']:
+
+        report_lines.append(
+            f"   检测到分卷: {'是' if analysis['has_volume'] else '否'}"
+        )
+
+        if analysis["sample_chapters"]:
             report_lines.append(f"   示例章节:")
-            for s in analysis['sample_chapters'][:3]:
+            for s in analysis["sample_chapters"][:3]:
                 report_lines.append(f"      • {s}")
         report_lines.append("")
 
@@ -909,27 +965,29 @@ def perform_check(bk, config):
                 pass
 
     all_missing = []
-    
+
     # 自动检测章节重置模式
     if auto_detect_reset and not enable_vol and all_chapters_ordered:
         segments = split_by_reset(all_chapters_ordered)
         if len(segments) > 1:
             report_lines.append(f"📊 检测到 {len(segments)} 个分段（章节号重置点）")
             report_lines.append("-" * 20)
-            
+
             has_content = False
             for idx, seg in enumerate(segments, 1):
                 if not seg:
                     continue
                 has_content = True
                 name = f"📑 分段 {idx}"
-                _, r, missing = check_sequence_report(seg, name, mode=mode, prev_end=None, original_order=seg)
+                _, r, missing = check_sequence_report(
+                    seg, name, mode=mode, prev_end=None, original_order=seg
+                )
                 report_lines.extend(r)
                 all_missing.extend(missing)
-            
+
             if not has_content:
                 report_lines.append("⚠️  未找到匹配的章节")
-            
+
             return "\n".join(report_lines), all_missing
 
     if enable_vol and len(volume_order) > 0:
@@ -960,7 +1018,11 @@ def perform_check(bk, config):
             prev_end = 0
 
         last_chap, r, missing = check_sequence_report(
-            chapters, name, mode=current_mode, prev_end=prev_end, original_order=chapters
+            chapters,
+            name,
+            mode=current_mode,
+            prev_end=prev_end,
+            original_order=chapters,
         )
         report_lines.extend(r)
         all_missing.extend(missing)


### PR DESCRIPTION
## 摘要

本 PR 优化了章节和分卷的正则匹配规则，并增强了代码的鲁棒性和可读性。

## 主要变更

### 1. 分卷正则扩展
- 新增支持：`辑`、`册`、`幕`、`篇` 等更多分段关键词
- 原：`[卷部]` → 新：`[卷部辑册幕篇]`

### 2. 正则安全性增强
- 对章节前缀使用 `re.escape()` 处理，防止特殊字符破坏正则
- 重构后缀处理逻辑：支持多后缀（`章|回`）的同时对每部分独立转义
- 同步更新了 3 个核心函数：
  - `analyze_chapter_format()`
  - `get_chapter_info_from_nav()`
  - `perform_check()`

### 3. 代码格式优化
- 字典定义改为每行一个键值对
- 长函数签名拆分为多行
- 添加适当的空行分隔逻辑块

## 关联 Issue

修复 #1

## 测试说明

- 需要在 Sigil 中手动测试
- 建议测试以下场景：
  - 标准章节格式（第1章、第一章）
  - 多后缀格式（第X章、第X回）
  - 分卷格式（第X卷、第X辑、第X册）
  - 特殊字符前缀（如带括号的前缀）